### PR TITLE
Fix state root witness

### DIFF
--- a/pkg/witness/builder.go
+++ b/pkg/witness/builder.go
@@ -20,7 +20,7 @@ import (
 func hexToNibbles(h [32]byte) []uints.U8 {
 	out := make([]uints.U8, 64)
 	for i, b := range h {
-		out[2*i] = mpt.ConstU8(b >> 4)   // high nibble
+		out[2*i] = mpt.ConstU8(b >> 4)     // high nibble
 		out[2*i+1] = mpt.ConstU8(b & 0x0f) // low  nibble
 	}
 	return out
@@ -58,18 +58,11 @@ func Build(
 		return nil, err
 	}
 
-	var (
-		accNodes    [][]uints.U8
-		firstAccRaw []byte
-	)
-	for i, h := range proof.AccountProof {
+	var accNodes [][]uints.U8
+	for _, h := range proof.AccountProof {
 		raw, _ := hex.DecodeString(h[2:])
-		if i == 0 {
-			firstAccRaw = raw
-		}
 		accNodes = append(accNodes, toU8Slice(raw))
 	}
-	rootByte := crypto.Keccak256(firstAccRaw)[0]
 
 	var storNodes [][]uints.U8
 	for _, h := range proof.StorageProof[0].Proof {
@@ -77,17 +70,17 @@ func Build(
 		storNodes = append(storNodes, toU8Slice(raw))
 	}
 
-	storLeaf   := storNodes[len(storNodes)-1]
-	payload    := storLeaf[1:]
-	ownerVal   := append([]uints.U8(nil), payload...)
+	storLeaf := storNodes[len(storNodes)-1]
+	payload := storLeaf[1:]
+	ownerVal := append([]uints.U8(nil), payload...)
 
-	accPath  := hexToNibbles(crypto.Keccak256Hash(contract.Bytes()))
-	slotKey  := slot.Calc(tokenID, 0)
+	accPath := hexToNibbles(crypto.Keccak256Hash(contract.Bytes()))
+	slotKey := slot.Calc(tokenID, 0)
 	storPath := hexToNibbles(slotKey)
 
 	assignment := &circuits.BaycOwnershipCircuit{
-		StateRoot: uint64(rootByte),
-		TokenID:   tokenID,
+		StateRoot:    headerRoot.Big(),
+		TokenID:      tokenID,
 		AccountProof: accNodes,
 		StorageProof: storNodes,
 		AccountPath:  accPath,
@@ -103,8 +96,20 @@ func Build(
 		StoragePath:  make([]uints.U8, len(storPath)),
 		OwnerBytes:   make([]uints.U8, len(ownerVal)),
 	}
-	for i, n := range accNodes  { ln := len(n); if ln == 0 { ln = 1 }; blue.AccountProof[i] = make([]uints.U8, ln) }
-	for i, n := range storNodes { ln := len(n); if ln == 0 { ln = 1 }; blue.StorageProof[i] = make([]uints.U8, ln) }
+	for i, n := range accNodes {
+		ln := len(n)
+		if ln == 0 {
+			ln = 1
+		}
+		blue.AccountProof[i] = make([]uints.U8, ln)
+	}
+	for i, n := range storNodes {
+		ln := len(n)
+		if ln == 0 {
+			ln = 1
+		}
+		blue.StorageProof[i] = make([]uints.U8, ln)
+	}
 
 	pub := PublicInputs{
 		StateRoot: headerRoot,


### PR DESCRIPTION
## Summary
- use the full 32-byte state root from the header when building a witness

## Testing
- `go test ./...`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6846caed72f883278be24db65fe74ff1