### PR TITLE
Implement RLP-aware node hashing

### DIFF
--- a/pkg/mpt/branch_test.go
+++ b/pkg/mpt/branch_test.go
@@ -9,7 +9,6 @@ import (
 	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/test"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type accHappyCircuit struct {
@@ -30,7 +29,6 @@ func (c *accHappyCircuit) Define(api frontend.API) error {
 /* ───────────────────────────── test ──────────────────────────── */
 
 func TestAccountLeafHappy(t *testing.T) {
-	digest := crypto.Keccak256([]byte{0})
 	curves := []struct {
 		id  ecc.ID
 		mod *big.Int
@@ -40,7 +38,7 @@ func TestAccountLeafHappy(t *testing.T) {
 	}
 
 	for _, c := range curves {
-		root := new(big.Int).SetBytes(digest)
+		root := big.NewInt(0)
 		root.Mod(root, c.mod)
 
 		assert := test.NewAssert(t)

--- a/pkg/mpt/hash.go
+++ b/pkg/mpt/hash.go
@@ -1,0 +1,32 @@
+package mpt
+
+import (
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/yourorg/bayczk/internal/keccak"
+)
+
+// HashNode returns the trie pointer corresponding to the given raw MPT node.
+// For nodes shorter than 32 bytes, the RLP bytes are interpreted directly as a
+// big-endian integer. Otherwise the Keccak256 hash of the node is used.
+func HashNode(api frontend.API, raw []uints.U8) frontend.Variable {
+	if len(raw) < 32 {
+		acc := frontend.Variable(0)
+		for _, b := range raw {
+			acc = api.Mul(acc, 256)
+			acc = api.Add(acc, b.Val)
+		}
+		return acc
+	}
+
+	h := keccak.New(api)
+	h.Write(raw)
+	digest := h.Sum()
+
+	acc := frontend.Variable(0)
+	for _, b := range digest {
+		acc = api.Mul(acc, 256)
+		acc = api.Add(acc, b.Val)
+	}
+	return acc
+}

--- a/pkg/mpt/hash_test.go
+++ b/pkg/mpt/hash_test.go
@@ -1,0 +1,78 @@
+package mpt
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/uints"
+	"github.com/consensys/gnark/test"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// circuit for short node hashing
+type hashShortCircuit struct {
+	Root frontend.Variable `gnark:",public"`
+}
+
+func (c *hashShortCircuit) Define(api frontend.API) error {
+	node := []uints.U8{b(0x01), b(0x02)}
+	api.AssertIsEqual(HashNode(api, node), c.Root)
+	return nil
+}
+
+// circuit for long node hashing (33 bytes)
+type hashLongCircuit struct {
+	Root frontend.Variable `gnark:",public"`
+}
+
+func (c *hashLongCircuit) Define(api frontend.API) error {
+	node := make([]uints.U8, 33)
+	for i := range node {
+		node[i] = b(byte(i))
+	}
+	api.AssertIsEqual(HashNode(api, node), c.Root)
+	return nil
+}
+
+func TestHashNodeVariants(t *testing.T) {
+	long := make([]byte, 33)
+	for i := range long {
+		long[i] = byte(i)
+	}
+
+	curves := []struct {
+		id  ecc.ID
+		mod *big.Int
+	}{
+		{ecc.BN254, bn254fr.Modulus()},
+		{ecc.BLS12_381, bls381fr.Modulus()},
+	}
+
+	for _, c := range curves {
+		// short case expected value
+		shortVal := new(big.Int).SetBytes([]byte{0x01, 0x02})
+		shortVal.Mod(shortVal, c.mod)
+
+		assert := test.NewAssert(t)
+		assert.ProverSucceeded(
+			new(hashShortCircuit),
+			&hashShortCircuit{Root: shortVal},
+			test.WithCurves(c.id),
+		)
+
+		// long case expected value
+		h := crypto.Keccak256(long)
+		longVal := new(big.Int).SetBytes(h)
+		longVal.Mod(longVal, c.mod)
+
+		assert.ProverSucceeded(
+			new(hashLongCircuit),
+			&hashLongCircuit{Root: longVal},
+			test.WithCurves(c.id),
+		)
+	}
+}

--- a/pkg/mpt/verify.go
+++ b/pkg/mpt/verify.go
@@ -31,7 +31,7 @@ type BranchInput struct {
 }
 
 func VerifyBranch(api frontend.API, in BranchInput) frontend.Variable {
-	api.AssertIsEqual(NodeHash(api, in.Nodes[0]), in.Root)
+	api.AssertIsEqual(HashNode(api, in.Nodes[0]), in.Root)
 
 	leaf := in.Nodes[len(in.Nodes)-1]
 	if len(in.LeafVal) != 0 {


### PR DESCRIPTION
## Summary
- introduce `HashNode` helper with inline/hashed node pointer logic
- refactor `VerifyBranch` to rely on `HashNode`
- adjust branch test and add `HashNode` unit tests
- update existing MPT tests to use witness-based root inputs

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6848158143508327b4c6367f70d359c2